### PR TITLE
fix(android): launch method in JitsiMeetViewExtended class is never called

### DIFF
--- a/android/src/main/java/com/reactnativejitsimeet/JitsiMeetActivityExtended.java
+++ b/android/src/main/java/com/reactnativejitsimeet/JitsiMeetActivityExtended.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.os.Bundle;
 
 import org.jitsi.meet.sdk.JitsiMeetActivity;
+import org.jitsi.meet.sdk.JitsiMeetConferenceOptions;
 import org.jitsi.meet.sdk.JitsiMeetView;
 
 public class JitsiMeetActivityExtended extends JitsiMeetActivity {
@@ -19,7 +20,7 @@ public class JitsiMeetActivityExtended extends JitsiMeetActivity {
     handlePictureInPicture();
   }
 
-  public static void launch(Context context, RNJitsiMeetConferenceOptions options) {
+  public static void launchExtended(Context context, JitsiMeetConferenceOptions options) {
     Intent intent = new Intent(context, JitsiMeetActivityExtended.class);
 
     intent.setAction("org.jitsi.meet.CONFERENCE");
@@ -33,7 +34,7 @@ public class JitsiMeetActivityExtended extends JitsiMeetActivity {
   }
 
   private void handlePictureInPicture() {
-    RNJitsiMeetConferenceOptions conferenceOptions = getIntent().getParcelableExtra("JitsiMeetConferenceOptions");
+    JitsiMeetConferenceOptions conferenceOptions = getIntent().getParcelableExtra("JitsiMeetConferenceOptions");
 
     if (conferenceOptions != null) {
       Bundle flags = conferenceOptions.getFeatureFlags();

--- a/android/src/main/java/com/reactnativejitsimeet/JitsiMeetModule.java
+++ b/android/src/main/java/com/reactnativejitsimeet/JitsiMeetModule.java
@@ -145,6 +145,6 @@ public class JitsiMeetModule extends ReactContextBaseJavaModule {
 
     builder.setFeatureFlag("pip.enabled", !options.hasKey("pipEnabled") || options.getBoolean("pipEnabled"));
 
-    JitsiMeetActivityExtended.launch(getReactApplicationContext(), builder.build());
+    JitsiMeetActivityExtended.launchExtended(getReactApplicationContext(), builder.build());
   }
 }


### PR DESCRIPTION
While trying to use an older version of the JitsiMeetSDK, the app was throwing the error:

```
Calling startActivity() from outside of an Activity  context requires the  
FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?
```

It turns out, the `launch` method within the `JitsiMeetViewExtended` subclass is never invoked because it is hidden by the superclass's own method (since it is a static method, we can't override it).

When using newer versions of JitsiMeetSDK, this bug goes unnoticed because the superclass `override` method implements the `FLAG_ACTIVITY_NEW_TASK` flag.
