### PR TITLE
feat: implement built-in config overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,12 +294,17 @@ buildscript {
 
 ## Options
 
-| key       | Data type | Default             | Description                                                                                            |
-| --------- | --------- | ------------------- | ------------------------------------------------------------------------------------------------------ |
-| room      | string    | required            | Room name for Jitsi Meet                                                                               |
-| serverUrl | string    | https://meet.jit.si | Valid server URL                                                                                       |
-| token     | string    | ""                  | JWT token                                                                                              |
-| userInfo  | object    | {}                  | Object that contains information about the participant starting the meeting. See [UserInfo](#userinfo) |
+| key          | Data type | Default             | Description                                                                                                     |
+| ------------ | --------- | ------------------- | --------------------------------------------------------------------------------------------------------------- |
+| room         | string    | required            | Room name for Jitsi Meet                                                                                        |
+| serverUrl    | string    | https://meet.jit.si | Valid server URL                                                                                                |
+| token        | string    | ""                  | JWT token                                                                                                       |
+| subject      | string    | ""                  | Conference subject (will change the global subject for all participants)                                        |
+| audioOnly    | boolean   | false               | Controls whether the participant will join the conference in audio-only mode (no video is sent or recieved)     |
+| audioMuted   | boolean   | false               | Controls whether the participant will join the conference with the microphone muted                             |
+| videoMuted   | boolean   | false               | Controls whether the participant will join the conference with the camera muted                                 |
+| userInfo     | object    | {}                  | Object that contains information about the participant starting the meeting. See [UserInfo](#userinfo)          |
+| featureFlags | object    | {}                  | Object that contains information about which feature flags should be set. See below for more info.              |
 
 ### Feature Flags
 

--- a/android/src/main/java/com/reactnativejitsimeet/JitsiMeetModule.java
+++ b/android/src/main/java/com/reactnativejitsimeet/JitsiMeetModule.java
@@ -93,6 +93,23 @@ public class JitsiMeetModule extends ReactContextBaseJavaModule {
       builder.setToken(options.getString("token"));
     }
 
+    // Set built-in config overrides
+    if (options.hasKey("subject")) {
+      builder.setSubject(options.getString("subject"));
+    }
+
+    if (options.hasKey("audioOnly")) {
+      builder.setAudioOnly(options.getBoolean("audioOnly"));
+    }
+
+    if (options.hasKey("audioMuted")) {
+      builder.setAudioMuted(options.getBoolean("audioMuted"));
+    }
+    
+    if (options.hasKey("videoMuted")) {
+      builder.setVideoMuted(options.getBoolean("videoMuted"));
+    }
+
     // Set the feature flags
     if (options.hasKey("featureFlags")) {
       ReadableMap featureFlags = options.getMap("featureFlags");

--- a/android/src/main/java/com/reactnativejitsimeet/JitsiMeetViewManager.java
+++ b/android/src/main/java/com/reactnativejitsimeet/JitsiMeetViewManager.java
@@ -109,9 +109,25 @@ public class JitsiMeetViewManager extends SimpleViewManager<RNJitsiMeetView> {
       }
     }
 
-
     if (options.hasKey("token")) {
       builder.setToken(options.getString("token"));
+    }
+
+    // Set built-in config overrides
+    if (options.hasKey("subject")) {
+      builder.setSubject(options.getString("subject"));
+    }
+
+    if (options.hasKey("audioOnly")) {
+      builder.setAudioOnly(options.getBoolean("audioOnly"));
+    }
+
+    if (options.hasKey("audioMuted")) {
+      builder.setAudioMuted(options.getBoolean("audioMuted"));
+    }
+    
+    if (options.hasKey("videoMuted")) {
+      builder.setVideoMuted(options.getBoolean("videoMuted"));
     }
 
     // Set the feature flags

--- a/ios/JitsiMeetUtil.swift
+++ b/ios/JitsiMeetUtil.swift
@@ -5,7 +5,7 @@ struct JitsiMeetUtil {
   static func buildConferenceOptions(_ options: NSDictionary) -> JitsiMeetConferenceOptions {
     return JitsiMeetConferenceOptions.fromBuilder { (builder) in
       guard let room = options["room"] as? String else {
-        fatalError("Room must no be empty")
+        fatalError("Room must not be empty")
       }
       
       builder.room = room
@@ -32,6 +32,23 @@ struct JitsiMeetUtil {
       
       if let token = options["token"] as? String {
         builder.token = token
+      }
+
+      // Set built-in config overrides
+      if let subject = options["subject"] as? String {
+        builder.subject = subject
+      }
+
+      if let audioOnly = options["audioOnly"] as? Bool {
+        builder.audioOnly = audioOnly
+      }
+
+      if let audioMuted = options["audioMuted"] as? Bool {
+        builder.audioMuted = audioMuted
+      }
+
+      if let videoMuted = options["videoMuted"] as? Bool {
+        builder.videoMuted = videoMuted
       }
         
       // Set the feature flags

--- a/ios/JitsiMeetUtil.swift
+++ b/ios/JitsiMeetUtil.swift
@@ -36,19 +36,19 @@ struct JitsiMeetUtil {
 
       // Set built-in config overrides
       if let subject = options["subject"] as? String {
-        builder.subject = subject
+        builder.setSubject(subject)
       }
 
       if let audioOnly = options["audioOnly"] as? Bool {
-        builder.audioOnly = audioOnly
+        builder.setAudioOnly(audioOnly)
       }
 
       if let audioMuted = options["audioMuted"] as? Bool {
-        builder.audioMuted = audioMuted
+        builder.setAudioMuted(audioMuted)
       }
 
       if let videoMuted = options["videoMuted"] as? Bool {
-        builder.videoMuted = videoMuted
+        builder.setVideoMuted(videoMuted)
       }
         
       // Set the feature flags

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,10 @@ export interface JitsiMeetConferenceOptions {
   serverUrl?: string;
   userInfo?: JitsiMeetUserInfo;
   token?: string;
+  subject?: string;
+  audioOnly?: boolean;
+  audioMuted?: boolean;
+  videoMuted?: boolean;
   featureFlags?: { [key: string]: boolean };
 }
 


### PR DESCRIPTION
This PR adds a few missing built-in config overrides provided by both of the native options builders:

+ subject: sets the global conference subject
+ audioOnly: toggles whether the participant will join in audio-only mode
+ audioMuted: toggles whether the participant will join with their microphone muted
+ videoMuted: toggles whether the participant will join with their camera muted

I considered adding these options to their own `JitsiMeetConfigOverrides` type or similar, but decided against it in case of naming conflicts if dynamic config overrides are implemented in the future.

I'm a bit of a beginner at touching native code so please let me know if I messed anything up. Tested on Android, appears to be working as expected - I'm unable to test on iOS at the moment but will as soon as I can (should be able to early next week).

closes #24